### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Development instructions for ClayGame
+
+- This project is a Python 3.10+ Pygame prototype.
+- Keep code compatible with Python 3.10 and follow PEP 8 with 4-space indentation.
+- Document new functions or modules with concise docstrings.
+- After modifying any `.py` files, ensure they compile with:
+  ```bash
+  python -m py_compile $(git ls-files '*.py')
+  ```
+- When adding new features or scripts, update `README.md` if usage or dependencies change.
+- Mention the relevant user request in each commit message.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for contributing to the ClayGame project

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68795b84eec0832494ff98a9651c61dd