### PR TITLE
Add high score reset helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Example battle setups are stored in `assets/scenes/`. The simple designer state
 (`scene_designer_state.py`) lets you drag sprites around and save a new template
 JSON file for later use.
 
+## High Scores
+Scores persist between runs in `highscore.txt`. The file is created
+automatically the first time you finish a game. A helper,
+`reset_high_score()`, is provided in `config.py` if you want to clear the
+recorded score without manually editing the file.
+
 The optional `voice_input.py` module demonstrates how to transcribe audio using
 the Whisper API, allowing future tools to create scenes from spoken commands.
 

--- a/config.py
+++ b/config.py
@@ -43,6 +43,11 @@ def save_high_score(score):
         print(f"Error saving high score: {e}")
 
 
+def reset_high_score() -> None:
+    """Reset the stored high score to zero."""
+    save_high_score(0)
+
+
 # Game state constants - used by the state manager to control game flow
 STATE_MENU = "menu"
 STATE_PLAYING = "playing"


### PR DESCRIPTION
## Summary
- add `reset_high_score()` helper function
- document high scores in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687961c46ad483249474a2f69634fd57