### PR TITLE
Add fullscreen toggle and high score display

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,17 @@
+# Next Steps in Game Development
+
+This document outlines recommended future improvements for the ClayGame project and summarizes recent enhancements.
+
+## Proposed Features
+
+- **Fullscreen Toggle**: Allow players to toggle fullscreen mode with `F11`. This improves immersion and accessibility for different screen sizes.
+- **High Score Display**: Show the saved high score on the main menu so players can see the target to beat.
+- **Save/Load Enhancements**: Integrate save and load options into the pause menu.
+- **Enemy Variety**: Introduce additional enemy behaviors (e.g., faster movement or unique attack patterns) to increase gameplay depth.
+- **Sound and Music**: Expand the audio system with background music tracks and more sound effects.
+
+## Implemented Changes
+
+- Added global `F11` key handling in `main.py` to toggle fullscreen mode at runtime.
+- Updated `MainMenu` in `states.py` to display the stored high score.
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Run the game using:
 python main.py
 ```
 
+Press `F11` while the game is running to toggle fullscreen. The main menu now shows your saved high score.
+
 ## Development
 
 Compiled Python files (`__pycache__`) and IDE settings are ignored using `.gitignore`. Feel free to open issues or pull requests with improvements.

--- a/main.py
+++ b/main.py
@@ -98,6 +98,7 @@ def main():
     pygame.init()
     screen = pygame.display.set_mode((800, 600))
     pygame.display.set_caption("Pixel War: Multiverse Battle")
+    fullscreen = False
 
     # Start with MainMenu.
     menu_state = MainMenu(screen)
@@ -116,6 +117,14 @@ def main():
             if event.type == pygame.QUIT:
                 pygame.quit()
                 sys.exit()
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_F11:
+                fullscreen = not fullscreen
+                if fullscreen:
+                    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+                else:
+                    screen = pygame.display.set_mode((800, 600))
+                for s in manager.states:
+                    s.screen = screen
 
         # Debug: check if Enter key is pressed.
         keys = pygame.key.get_pressed()

--- a/states.py
+++ b/states.py
@@ -186,6 +186,7 @@ class MainMenu:
         """
         self.screen = screen
         self.font = pygame.font.SysFont("arial", 32) # Font for menu text
+        self.high_score = load_high_score()  # Show stored high score
         logger.debug("MainMenu initialized.")
 
     def process_events(self, events: list[pygame.event.Event]) -> str | None:
@@ -220,9 +221,15 @@ class MainMenu:
         Draws the main menu title and instructions on the screen.
         """
         self.screen.fill((0, 0, 0)) # Black background
-        title_surface = self.font.render("Main Menu - Press ENTER to start", True, (255, 255, 255)) # Render title text
-        title_rect = title_surface.get_rect(center=(self.screen.get_width() // 2, self.screen.get_height() // 2)) # Center title
-        self.screen.blit(title_surface, title_rect) # Draw title
+        title_surface = self.font.render("Main Menu - Press ENTER to start", True, (255, 255, 255))
+        title_rect = title_surface.get_rect(center=(self.screen.get_width() // 2, self.screen.get_height() // 2))
+        self.screen.blit(title_surface, title_rect)
+
+        hs_text = f"High Score: {self.high_score}"
+        hs_surface = self.font.render(hs_text, True, (255, 255, 0))
+        hs_rect = hs_surface.get_rect(center=(self.screen.get_width() // 2, self.screen.get_height() // 2 + 40))
+        self.screen.blit(hs_surface, hs_rect)
+
         pygame.display.flip() # Update display
 
 


### PR DESCRIPTION
## Summary
- show the saved high score on the main menu
- allow toggling fullscreen with F11
- document new features
- outline next steps for development

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68796aa106988324be53cd87330b4fcc