### PR TITLE
Add screenshot feature and planning file

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,6 @@
+# Next Steps
+
+- [x] Add ability to capture a screenshot with F12 key during gameplay.
+- [ ] Implement player inventory UI.
+- [ ] Create additional enemy types and behaviors.
+- [ ] Expand level data format to support interactive NPCs.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ scenario.  Use the arrow keys to move and space to advance dialogue.
 ## Debugging
 Press **F3** during gameplay to toggle an overlay showing the current FPS and
 player position. This can help when tuning sprite behavior or level layouts.
+Press **F12** to save a screenshot in the `screenshots/` folder.
 
 ## Asset Generation
 The repository includes a script, `generate_assets.py`, which creates placeholder

--- a/screenshot_utils.py
+++ b/screenshot_utils.py
@@ -1,0 +1,12 @@
+import os
+import pygame
+from datetime import datetime
+
+
+def capture_screenshot(screen: pygame.Surface, directory: str = "screenshots") -> str:
+    """Save a screenshot of the given screen to the specified directory."""
+    os.makedirs(directory, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    path = os.path.join(directory, f"screenshot_{timestamp}.png")
+    pygame.image.save(screen, path)
+    return path

--- a/states.py
+++ b/states.py
@@ -9,6 +9,7 @@ from sprites import (
     Explosion, ParallaxBackground, Fortress, Village
 )
 from resources import load_image_with_scale, get_asset_path
+from screenshot_utils import capture_screenshot
 
 logger = logging.getLogger(__name__) # Set up logger for this module
 
@@ -572,6 +573,9 @@ class PlayingState:
                     # Toggle debug overlay when F3 is pressed
                     self.show_debug_info = not self.show_debug_info
                     logger.debug(f"Debug overlay toggled to {self.show_debug_info}")
+                elif event.key == pygame.K_F12:
+                    path = capture_screenshot(self.screen)
+                    logger.info(f"Screenshot saved to {path}")
         return None # No state change
 
     def _fire_projectile(self):


### PR DESCRIPTION
## Summary
- add F12 screenshot capture and log saved path
- document screenshot shortcut in README
- outline future development steps
- provide helper function `capture_screenshot`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68796f761ff0832482e605609a51ad24